### PR TITLE
fix(wake): stop the wake word leaking through as a command

### DIFF
--- a/src/voicecommand/voice_LED_control.py
+++ b/src/voicecommand/voice_LED_control.py
@@ -217,21 +217,36 @@ class VoiceProcessor:
             self.rgb = None
             self.logger.warning(f"MQTT RGB controller unavailable: {e}")
 
+    def _is_wake_token(self, tok):
+        """True if a single token is the wake word or a close mishearing."""
+        t = tok.lower().strip(".,!?;:'\"")
+        return (
+            t in self.wake_aliases
+            or difflib.SequenceMatcher(None, t, self.wake_word).ratio() >= 0.72
+        )
+
     def _strip_wake_word(self, text):
         """Detect the wake word and return (heard, command_text).
 
         Scans tokens for an exact alias or a close phonetic match (handles STT
-        mishearings like 'clink'/'crank'/'blank'). On a hit, everything after
-        the wake word is the command; text before/including it is dropped.
+        mishearings like 'clink'/'crank'/'blank'). On a hit, the wake word AND
+        any wake-word echoes immediately following it are dropped; everything
+        after that is the command.
+
+        Stripping every leading wake token (not just the first) matters for the
+        acoustic engine: the capture's pre-roll keeps the tail of "...clank",
+        which transcribes as a leading "clank" — sometimes doubled — so a
+        single-strip would leak "clank" to the LLM as a bogus command (it comes
+        back as color="clank"). Here "clank clank" -> "" (discarded) and
+        "clank clank red" -> "red".
         """
         tokens = text.split()
         for i, tok in enumerate(tokens):
-            t = tok.lower().strip(".,!?;:'\"")
-            if (
-                t in self.wake_aliases
-                or difflib.SequenceMatcher(None, t, self.wake_word).ratio() >= 0.72
-            ):
-                return True, " ".join(tokens[i + 1:]).strip()
+            if self._is_wake_token(tok):
+                j = i + 1
+                while j < len(tokens) and self._is_wake_token(tokens[j]):
+                    j += 1
+                return True, " ".join(tokens[j:]).strip()
         return False, ""
 
     def process_command(self, text):


### PR DESCRIPTION
## Problem

Quick-fire voice commands frequently failed with `LLM response validation failed: Invalid color: clank` (or `Empty transcription`), and the assistant felt "stuck" — wake word fires, nothing happens, you repeat it.

The logs showed wake→command latency was a steady 1–3s, so there was no actual processing freeze. The "stuck" feeling was a run of commands silently failing.

## Root cause

With the openWakeWord engine, the capture pre-roll (0.5s) deliberately keeps the audio just before the wake fired — which is the tail of "...clank". So transcripts often start with a stray `clank`, sometimes doubled (`clank clank`), sometimes with no real command after it.

`_strip_wake_word` only removed the **first** wake token, so the survivor reached the LLM as the command and came back as `color="clank"` → rejected by validation, real command lost.

## Fix

`_strip_wake_word` now consumes **every** consecutive leading wake token:

- `clank` / `clank clank` → `""` → discarded as wake-only (no LLM call, no error)
- `clank clank red` → `red` → honored
- normal commands (`make it blue`) untouched

Split the per-token test into `_is_wake_token`.

Verified against the exact failure transcripts; `py_compile` clean. No tests in repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)