### PR TITLE
fix(rgb): align effect vocabulary to what the strip can render

### DIFF
--- a/src/voicecommand/validation.py
+++ b/src/voicecommand/validation.py
@@ -41,6 +41,16 @@ COLOR_RGB = {
 # changes together over time. Spatial effects (wipe, chase, scanner, comet,
 # meteor, fireworks, etc.) are excluded because they need addressable pixels to
 # be visible — on a single analog pixel they collapse to solid or a plain blink.
+# Spoken effect name -> WLED FX id. Restricted to the effects WLED actually
+# offers for our single-pixel (len:1) analog RGB segment — i.e. the temporal
+# effects that animate one colour zone. Spatial effects (Rainbow, Saw, Sine,
+# Wipe, Chase, ...) are hidden by WLED on a 1-pixel segment because they need
+# length to render, so they're deliberately NOT mapped here: sending them would
+# silently do nothing. Audio-reactive effects (DJ Light, Freqwave, Waterfall,
+# ...) are also omitted — the AudioReactive usermod is disabled and no mic is
+# wired, so they'd never animate. IDs verified live against the device's
+# /json/eff. If you ever wire an I2S mic + enable AudioReactive, the reactive
+# effects can be added back.
 WLED_EFFECTS = {
     # steady
     "solid":          0,
@@ -53,16 +63,14 @@ WLED_EFFECTS = {
     "pulse":          2,
     "breathing":      2,
     "fade":           12,
-    "saw":            16,
-    "sawtooth":       16,
-    "sine":           108,
     "heartbeat":      100,
     "heart beat":     100,
-    # colour cycling
+    # colour cycling. WLED's spatial "Rainbow" (9) is dead on one pixel, so the
+    # common spoken word "rainbow" maps to Colorloop (8), which cycles the hue
+    # of the single zone — exactly what people mean by "rainbow" here.
     "random":         5,
     "random colors":  5,
     "random colours": 5,
-    "dynamic":        7,
     "colorloop":      8,
     "colourloop":     8,
     "color loop":     8,
@@ -70,7 +78,7 @@ WLED_EFFECTS = {
     "cycle":          8,
     "cycle colors":   8,
     "cycle colours":  8,
-    "rainbow":        9,
+    "rainbow":        8,
     # flashing / strobe family
     "strobe":         23,
     "flash":          23,
@@ -80,7 +88,6 @@ WLED_EFFECTS = {
     "mega strobe":    25,
     "blink rainbow":  26,
     "rainbow blink":  26,
-    "lightning":      57,
     # flicker / fire
     "candle":         88,
     "flicker":        88,
@@ -89,6 +96,10 @@ WLED_EFFECTS = {
     "fire":           45,
     "fire flicker":   45,
     "flame":          45,
+    # misc
+    "tv":             116,
+    "tv simulator":   116,
+    "television":     116,
 }
 
 class LEDColor(Enum):

--- a/src/voicecommand/voice_LED_control.py
+++ b/src/voicecommand/voice_LED_control.py
@@ -40,12 +40,12 @@ parameters the user actually asked for:
 - "color": one of red, green, blue, white, warm white, yellow, orange, amber,
   purple, violet, pink, magenta, cyan, teal, turquoise, lime, gold
 - "brightness": integer 0-100 (a percentage)
-- "effect": one of solid, blink, breathe, fade, saw, sine, heartbeat, random,
-  dynamic, colorloop, rainbow, strobe, strobe rainbow, strobe mega, blink
-  rainbow, lightning, candle, fire. Use "solid" for a plain steady colour or
-  "stop the effect". Map intent: "pulse"/"breathing" -> breathe, "cycle
-  colours" -> colorloop, "flicker"/"candle light" -> candle, "flash" -> strobe,
-  "flames" -> fire, "random colours" -> random, "thunder" -> lightning.
+- "effect": one of solid, blink, breathe, fade, heartbeat, random, colorloop,
+  rainbow, strobe, strobe rainbow, strobe mega, blink rainbow, candle, fire, tv.
+  Use "solid" for a plain steady colour or "stop the effect". Map intent:
+  "pulse"/"breathing" -> breathe, "cycle colours" -> colorloop, "rainbow" ->
+  rainbow, "flicker"/"candle light" -> candle, "flash" -> strobe, "flames" ->
+  fire, "random colours" -> random, "tv"/"fake tv" -> tv.
 - "speed": integer 0-100 — how FAST the current effect animates (0 = slowest,
   100 = fastest). Use for "faster/quicker/speed up" -> a high value like 85;
   "slower/calmer" -> a low value like 20.


### PR DESCRIPTION
## Problem

Several mapped effects did nothing when spoken, which read as "command not honoured":

- On our single-pixel (`len:1`) analog segment, WLED **hides spatial effects** (they need length to render). `Rainbow(9)`, `Saw(16)`, `Sine(108)`, `Dynamic(7)`, `Lightning(57)` were in the vocabulary but render as nothing.
- The 9 audio-reactive effects are also dead — the AudioReactive usermod is `enabled:false` and no mic is wired.

## Fix

Verified the device's actual list via live `/json/eff` and cross-referenced WLED's filtered UI list for this segment:

- **Drop** the dead spatial mappings (saw/sine/dynamic/lightning) and the spatial Rainbow.
- **Remap** spoken `"rainbow"` → `Colorloop(8)` — a genuine hue cycle on the single zone, which is what people actually mean.
- **Add** `TV Simulator(116)`.
- Update the LLM system prompt to match the trimmed list.

Vocabulary is now exactly the temporal effects the strip can show: solid, blink, blink rainbow, breathe, candle, colorloop (= rainbow), fade, fire, heartbeat, random, strobe, strobe mega, strobe rainbow, tv.

`py_compile` clean; effect map sanity-checked.

> If an I2S mic is added and AudioReactive enabled later, the reactive effects (DJ Light, Freqwave, Waterfall, …) can be added back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)