### PR TITLE
feat(rgb): remember last look across a mains power-cycle

### DIFF
--- a/config/default.yaml
+++ b/config/default.yaml
@@ -50,6 +50,9 @@ mqtt:
   broker_host: "127.0.0.1"
   broker_port: 1883
   rgb_set_topic: "wled/clank/api"
+  # Save the resulting look into this WLED preset after each command so a mains
+  # power-cycle restores it (the device boots into this slot). 0 disables it.
+  persist_preset: 1
 
 # Network Settings
 network:

--- a/src/voicecommand/config.py
+++ b/src/voicecommand/config.py
@@ -69,6 +69,11 @@ class MqttConfig:
     broker_host: str = "127.0.0.1"
     broker_port: int = 1883
     rgb_set_topic: str = "wled/clank/api"
+    # After each command, snapshot the resulting look into this WLED preset slot
+    # so a mains power-cycle restores it (the device boots into this slot via
+    # its def.ps setting) instead of the factory amber default. Set to 0 to
+    # disable and avoid a flash write per command.
+    persist_preset: int = 1
 
 @dataclass
 class NetworkConfig:

--- a/src/voicecommand/voice_LED_control.py
+++ b/src/voicecommand/voice_LED_control.py
@@ -370,6 +370,24 @@ class VoiceProcessor:
                 elif state == "on" or seg or "brightness" in params:
                     wled["on"] = True
 
+                # Persist the resulting look so a mains power-cycle restores it.
+                # WLED's "psave" snapshots the live state (after this call's
+                # changes are applied) into a preset slot; the device is set to
+                # boot into that slot (def.ps), so the strip comes back exactly
+                # as it was instead of the factory amber default. Set
+                # mqtt.persist_preset to 0 to disable (avoids a flash write per
+                # command).
+                # ib/sb make the preset include master brightness + on-state and
+                # the segment, so the whole look is restored (a bare psave only
+                # stores the segment colour). WLED applies this call's changes
+                # first, then snapshots the resulting live state into the slot.
+                slot = self.config.mqtt.persist_preset
+                if slot:
+                    wled["psave"] = slot
+                    wled["n"] = "clank-last"
+                    wled["ib"] = True
+                    wled["sb"] = True
+
                 # Log the resolved command (never the raw speech).
                 self.logger.info(f"Command(rgb): {params}")
                 if self.rgb is None:


### PR DESCRIPTION
## Problem

After turning the strip off/on at the mains it always came back **amber/yellow** — WLED's factory default colour — because no boot preset was configured (`def.ps = 0`) and the build has no Autosave usermod, so the live state wasn't persisted.

## Fix

Each Clank command now snapshots the resulting look into a WLED preset (default slot **1**) and the device is set to boot into that slot, so a mains cut restores exactly what it was last set to.

- `set_rgb` adds `psave`/`n`/`ib`/`sb` to the same JSON it already publishes. WLED applies the state change first, then snapshots — and `ib`/`sb` make the preset capture master **brightness + on-state + segment**, not just the segment colour (a bare `psave` drops brightness/on).
- New config knob `mqtt.persist_preset` (default `1`; set `0` to disable and avoid a flash write per command).
- One-time device settings applied on the strip: `def.ps = 1` (boot preset) and preset 1 seeded.

## Verification (live, on device)

- Combined `psave` with `ib:true,sb:true` saved `on:true, bri:77, col:[255,0,255]`.
- Disturbed the strip to white/full, then applied preset 1 (what boot does via `def.ps=1`) → restored magenta `bri 77` exactly.

> Note: `psave` writes to flash per command. Negligible for occasional voice use; `persist_preset: 0` disables it. Faithful memory means if you turn it **off** then cut mains, it boots back off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)