### PR TITLE
Offer to keep the Ollama model warm (OLLAMA_KEEP_ALIVE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,26 @@ pip install -r requirements.txt
 
    Any model that reliably outputs clean JSON works. **`qwen3:14b` will not fit in 4 GB of VRAM** — only choose it if you have a larger GPU.
 
+3. **(Recommended for a dedicated box) Keep the model loaded for instant responses.**
+
+   By default Ollama evicts the model from (V)RAM after ~5 minutes idle, so the
+   first command after a pause is slow while it reloads. To keep it resident,
+   set `OLLAMA_KEEP_ALIVE=-1` on the Ollama service. The installer offers to do
+   this for you; to set it by hand on a systemd system:
+
+   ```bash
+   sudo systemctl edit ollama
+   ```
+   Add:
+   ```ini
+   [Service]
+   Environment="OLLAMA_KEEP_ALIVE=-1"
+   ```
+   then `sudo systemctl restart ollama` and verify with `ollama ps` (the
+   **UNTIL** column reads *Forever*). This only holds VRAM while idle — there's
+   no compute and no GPU wear. Use a duration like `30m` instead of `-1` if you
+   also use the GPU for other things and want it freed after you stop talking.
+
 ---
 
 ## Step 3 — Fetch the Moonshine models

--- a/install.sh
+++ b/install.sh
@@ -219,10 +219,46 @@ check_ollama() {
         else
             print_warning "Ollama service not running. Start with: ollama serve"
         fi
+
+        configure_ollama_keepalive
     else
         print_warning "Ollama not found. Please install from https://ollama.ai"
         print_info "After installing Ollama, run: ollama pull $OLLAMA_MODEL"
     fi
+}
+
+configure_ollama_keepalive() {
+    # By default Ollama evicts the model from (V)RAM after ~5 min idle, so the
+    # first command after a pause pays a slow cold reload. On a dedicated Clank
+    # box you usually want it resident for instant responses — this just holds
+    # VRAM while idle (no compute, no GPU wear).
+    if ! command -v systemctl &> /dev/null || \
+       ! systemctl list-unit-files 2>/dev/null | grep -q '^ollama\.service'; then
+        print_info "Ollama isn't a systemd service here — to keep the model warm,"
+        print_info "start it with OLLAMA_KEEP_ALIVE=-1 in its environment."
+        return 0
+    fi
+
+    echo
+    print_info "Ollama unloads the model after ~5 min idle (slow first command)."
+    print_info "Keeping it loaded gives instant responses (holds VRAM; no GPU wear)."
+    read -p "Keep the LLM loaded in VRAM permanently (OLLAMA_KEEP_ALIVE=-1)? (Y/n): " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Nn]$ ]]; then
+        print_info "Leaving Ollama's default unload behaviour (set later by re-running)."
+        return 0
+    fi
+
+    local dropin="/etc/systemd/system/ollama.service.d/keepalive.conf"
+    print_info "Writing $dropin (needs sudo)..."
+    sudo mkdir -p "$(dirname "$dropin")"
+    sudo tee "$dropin" > /dev/null <<'DROPIN'
+[Service]
+Environment="OLLAMA_KEEP_ALIVE=-1"
+DROPIN
+    sudo systemctl daemon-reload
+    sudo systemctl restart ollama
+    print_info "Ollama will keep models resident. Verify with: ollama ps (UNTIL = Forever)."
 }
 
 setup_configuration() {


### PR DESCRIPTION
## What
On a dedicated Clank box you don't want Ollama unloading the model after ~5 min idle — the first command after a pause then pays a slow cold reload.

- **`install.sh`** — new `configure_ollama_keepalive()` runs during the Ollama step: prompts (default **yes**) and, on a systemd host, writes a drop-in `/etc/systemd/system/ollama.service.d/keepalive.conf` setting `OLLAMA_KEEP_ALIVE=-1`, then `daemon-reload` + `restart`. If Ollama isn't a systemd service it prints the env-var hint instead.
- **`README.md`** — documents the setting in the Ollama step, including the no-GPU-wear note (idle VRAM hold = no compute) and the `30m` alternative for machines whose GPU is shared with other work.

## Why -1
This box is now purely a Clank box, so keeping `qwen3:4b` resident for instant responses is the right default; holding VRAM while idle causes no GPU wear.

## Test
`bash -n install.sh` passes. The drop-in approach is the standard systemd override pattern; `ollama ps` shows `UNTIL = Forever` once loaded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)