### PR TITLE
feat(wakeword): training guide + scripts, and pin all deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ models/*
 models/wakeword/*
 !models/wakeword/hey_clank.onnx
 
+# Wake-word training clips — personal recordings of your voice/room, kept local.
+# Only the trained, audited model (models/wakeword/hey_clank.onnx) is committed.
+data/
+
 # Logs
 logs/
 

--- a/README.md
+++ b/README.md
@@ -363,6 +363,15 @@ Clank only acts on speech that contains the wake word. There are two engines, se
 
 Stick with `text` unless you have a tuned acoustic model.
 
+### Training your own "hey clank" model
+
+If `openwakeword` misses the wake word on your mic (recall drops on a microphone
+the model never trained on), retrain it on **your** mic. The full walkthrough —
+recording clips, running the trainer, and the mandatory audit + SHA256 re-pin —
+is in **[docs/training-wakeword.md](docs/training-wakeword.md)**. Helper scripts
+live in `scripts/train_wakeword/` (`record_samples.py` to capture clips,
+`audit_onnx.py` to vet and hash the result before Clank will load it).
+
 ---
 
 ## Configuration reference

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,69 @@
+# Dependency audit & pinning
+
+Clank runs entirely on-box, but it still pulls Python wheels from PyPI at install
+time, so every direct dependency is **pinned to an exact version** and was
+checked against the genuine, canonical project before pinning. This file is the
+record of that audit; the pins live in `requirements.txt` and
+`requirements-secure.txt`.
+
+Runtime environment audited: **Python 3.14.5** on the Clank box, verified
+2026-06-13 with `pip freeze`.
+
+## Runtime packages
+
+| Package | Pin | Project / publisher | Why we trust it |
+|---|---|---|---|
+| `numpy` | `2.4.6` | NumPy team | Foundational numerics; ubiquitous. |
+| `onnxruntime` | `1.26.0` | Microsoft | Runs Moonshine + the wake-word ONNX on CPU. |
+| `tokenizers` | `0.23.1` | Hugging Face | Moonshine's tokenizer. |
+| `silero-vad` | `6.2.1` | snakers4 (MIT) | Voice-activity gate. [github.com/snakers4/silero-vad](https://github.com/snakers4/silero-vad) |
+| `useful-moonshine-onnx` | `20251121` | Useful Sensors | Moonshine STT inference (ONNX). [pypi.org/project/useful-moonshine-onnx](https://pypi.org/project/useful-moonshine-onnx/) |
+| `sounddevice` | `0.5.5` | spatialaudio (PortAudio bindings) | Mic capture. |
+| `requests` | `2.34.2` | PSF / requests team | HTTP to the local Ollama LLM. |
+| `openwakeword` | `0.4.0` | David Scripka (`dscripka`) | Acoustic "hey clank" gate. [github.com/dscripka/openWakeWord](https://github.com/dscripka/openWakeWord) |
+| `PyYAML` | `6.0.3` | PyYAML team | Config + device-registry parsing. |
+| `paho-mqtt` | `2.1.0` | Eclipse Foundation (Paho) | Publishes commands to mosquitto. |
+
+Dev-only (not imported at runtime): `pytest==8.4.2`, `black==25.9.0`,
+`flake8==7.3.0`.
+
+`openwakeword` is held at **0.4.0 on purpose**: it's the last release installable
+on Python 3.14 (later releases need `tflite-runtime`, which has no 3.14 wheel),
+it's ONNX-only, and it bundles its models so it runs fully offline.
+
+## The part that actually matters: the ONNX models
+
+Pinning wheels stops a *package* from changing under us. It does **not** vet the
+model weights — and ONNX is an executable graph format, so a malicious or
+swapped `.onnx` is the real risk. Clank handles model files separately:
+
+- **Moonshine STT** weights are fetched from an immutable Hugging Face commit by
+  `scripts/fetch_moonshine.sh` and checked against `SHA256SUMS`
+  (`sha256sum -c SHA256SUMS` from the repo root).
+- **Wake-word models** (the openWakeWord bundled feature models, the builtins,
+  and our own `models/wakeword/hey_clank.onnx`) are SHA256-pinned in
+  `_KNOWN_OWW_SHA256` in `src/voicecommand/voice_LED_control.py` and
+  integrity-checked **before** `onnxruntime` is allowed to touch them. A known
+  model that fails its hash is refused; an unknown model logs its hash so you
+  can audit and pin it.
+
+When you train a **new** `hey_clank.onnx`, you must re-audit and re-pin it — see
+[training-wakeword.md](training-wakeword.md), which uses
+`scripts/train_wakeword/audit_onnx.py` to do the structural check and print the
+hash to paste back into `_KNOWN_OWW_SHA256`.
+
+## Re-verifying / re-pinning
+
+```fish
+# What's actually installed right now:
+.venv/bin/pip freeze
+
+# Confirm a package's publisher/history before bumping a pin:
+.venv/bin/pip index versions <package>
+
+# Model integrity:
+sha256sum -c SHA256SUMS          # Moonshine
+# wake models are checked automatically at Clank startup
+```
+
+After bumping any pin: re-test, then update the table above.

--- a/docs/training-wakeword.md
+++ b/docs/training-wakeword.md
@@ -1,0 +1,165 @@
+# Training the "hey clank" wake word
+
+Clank's wake gate is a small openWakeWord ONNX model (`models/wakeword/hey_clank.onnx`).
+The shipped model was trained mostly on **synthetic** speech, which is why recall
+drops on a microphone it never "heard" during training — the symptom you hit on
+the laptop: a headset scores 0.7–0.9 but the built-in mic barely clears 0.1.
+
+The durable fix is to **retrain with audio from the mic Clank actually uses**.
+This guide covers doing that on the Clank box itself.
+
+> Security rule for this project: **a `.onnx` is executable graph code.** Any
+> model that lands on the Clank box must pass `scripts/train_wakeword/audit_onnx.py`
+> and be SHA256-pinned in `_KNOWN_OWW_SHA256` before Clank will load it. Never
+> drop an unaudited model into `models/wakeword/`.
+
+---
+
+## Can I train on the laptop? Yes.
+
+VRAM is **not** the bottleneck. openWakeWord's heavy feature extractors
+(melspectrogram + embedding) are frozen; you only train a tiny classifier head.
+The real costs are:
+
+- **Disk** — the augmentation/negative feature sets are several GB to download.
+- **CPU time** — generating synthetic speech (Piper TTS) is the slow step.
+- **Setup** — a separate Python 3.11 environment (the runtime venv is 3.14 and
+  can't run the training stack).
+
+A 4 GB dGPU is plenty; it'll even run CPU-only, just slower. Budget an evening,
+not a weekend. Bonus of training here: you record and train on the *same*
+acoustic path Clank listens through.
+
+---
+
+## Two approaches
+
+| | Full retrain | Custom verifier |
+|---|---|---|
+| Output | a new `hey_clank.onnx` | a `.pkl` verifier on top of a base model |
+| Data needed | synthetic + real clips + negatives | ~3 positive + ~10s negative clips |
+| Effort | an evening | minutes |
+| Fits Clank as-is? | **Yes** — drop-in replacement | No — Clank's loader expects an `.onnx`; using a verifier needs a small code change |
+
+For closing the mic-recall gap, do the **full retrain** — it's the supported,
+drop-in path. The verifier is a quick personalization trick but doesn't slot
+into Clank's current model loader, so it's noted at the end only.
+
+---
+
+## Full retrain — step by step
+
+### 1. Build the training environment (Python 3.11, separate venv)
+
+```fish
+python3.11 -m venv ~/oww-training/.venv
+source ~/oww-training/.venv/bin/activate.fish
+pip install -r scripts/train_wakeword/requirements-training.txt
+```
+
+If a version fails to resolve, the upstream notebook is the source of truth:
+<https://github.com/dscripka/openWakeWord/blob/main/notebooks/automatic_model_training.ipynb>.
+The maintained local/Docker pipeline at
+<https://github.com/CoreWorxLab/openwakeword-training> is a good fallback when
+the Colab notebook breaks (it often does).
+
+### 2. Record real clips from the Clank mic
+
+This is the step that actually fixes recall. Run it **in the Clank runtime venv**
+(it uses `sounddevice`/`soundfile`, which are already there), on the laptop, with
+the mic at its sweet spot (~55% gain — too low is quiet, too high clips):
+
+```fish
+# 50+ positive "hey clank" clips — vary distance, volume, cadence, who's speaking
+.venv/bin/python scripts/train_wakeword/record_samples.py --label positive --count 50
+
+# 30 hard negatives — talk, TV, similar words, but NEVER the wake word
+.venv/bin/python scripts/train_wakeword/record_samples.py --label negative --count 30 --seconds 3
+```
+
+Clips land in `data/wakeword/positive/` and `data/wakeword/negative/`
+(gitignored — they're personal audio, see below). More variety > more clips.
+
+### 3. Generate synthetic positives (Piper)
+
+The bulk of positive training data is synthetic speech across many voices:
+
+```fish
+git clone https://github.com/rhasspy/piper-sample-generator ~/oww-training/piper-sample-generator
+# follow its README to fetch a generator voice, then:
+python ~/oww-training/piper-sample-generator/generate_samples.py "hey clank" \
+    --max-samples 2000 --output-dir ~/oww-training/synthetic_positive
+```
+
+### 4. Get the negative / background feature sets
+
+The trainer mixes in large precomputed negative and room-impulse sets (AudioSet,
+FMA, RIRs). The training notebook downloads these from Hugging Face — follow its
+"data" cells. This is the multi-GB disk cost.
+
+### 5. Train
+
+Run the openWakeWord trainer (the notebook, or its `train.py` equivalent),
+pointing it at:
+- synthetic positives (step 3) **+** your real positives (`data/wakeword/positive/`),
+- your hard negatives (`data/wakeword/negative/`) plus the downloaded negatives,
+- export format: **ONNX** (Clank uses onnxruntime; you don't need the tflite export).
+
+Output is a new `hey_clank.onnx`.
+
+### 6. Audit the model (mandatory)
+
+```fish
+python scripts/train_wakeword/audit_onnx.py ~/oww-training/output/hey_clank.onnx
+```
+
+It hard-fails on custom operator domains, external-data tensors, or embedded
+URLs/paths, and confirms it loads under stock onnxruntime CPU. On success it
+prints the exact SHA256 line to pin. **If it fails, do not ship the model.**
+
+### 7. Pin and install
+
+1. Copy the line the audit printed into `_KNOWN_OWW_SHA256` in
+   `src/voicecommand/voice_LED_control.py`, replacing the old `hey_clank.onnx`
+   entry (update the dated audit comment above it).
+2. Put the model in place:
+   ```fish
+   cp ~/oww-training/output/hey_clank.onnx models/wakeword/hey_clank.onnx
+   ```
+3. Restart Clank. At startup the loader re-hashes the file and refuses to run if
+   it doesn't match the pin — so a typo here fails loudly, by design.
+
+### 8. Verify recall
+
+```fish
+./start_clank.sh --oww-debug
+```
+
+`--oww-debug` logs the peak wake score each second. Say "hey clank" from across
+the room a dozen times; you want consistent peaks well above the
+`oww_threshold` (currently **0.15** in `config/default.yaml`). If real hits now
+sit at 0.5–0.9 on the built-in mic, the retrain worked. Raise the threshold back
+toward 0.3–0.5 if you start getting false triggers.
+
+---
+
+## A note on the recorded clips & privacy
+
+`data/wakeword/` is gitignored — those are recordings of your voice and room and
+shouldn't be committed. Only the trained, audited `hey_clank.onnx` ships in the
+repo. (This matches Clank's runtime stance: live audio is RAM-only and never
+written to disk; these training clips are the one deliberate exception, kept
+local.)
+
+---
+
+## Quick option: custom verifier (does NOT drop into Clank as-is)
+
+openWakeWord can train a lightweight per-speaker *verifier* on a base model from
+just a handful of clips (`openwakeword.train_custom_verifier(...)`, see the
+[upstream docs](https://github.com/dscripka/openWakeWord/blob/main/docs/custom_verifier_models.md)).
+It outputs a `.pkl` that gates an existing wake model's detections. Clank's
+loader (`WakeWordDetector`) currently consumes a single `.onnx` and has no
+verifier hook, so using this would mean a small code change to load and apply the
+verifier alongside the base model. Noted for completeness; the full retrain above
+is the supported path.

--- a/requirements-secure.txt
+++ b/requirements-secure.txt
@@ -1,22 +1,26 @@
 # Clank dependencies + development/testing tools.
 # Superset of requirements.txt (install.sh prefers this file when present).
+#
+# Versions are PINNED (==) to the exact releases audited and running on the
+# Clank box (Python 3.14.5, verified 2026-06-13). Each direct dependency was
+# confirmed genuine on PyPI before pinning — see docs/dependencies.md.
 
-# Core runtime
-numpy>=1.21.0
-onnxruntime>=1.15.0
-tokenizers>=0.13.0
-silero-vad>=4.0.0
-sounddevice>=0.4.6
-requests>=2.28.0                 # HTTP to the local Ollama LLM
-useful-moonshine-onnx>=20251121  # Moonshine STT (local, hash-verified models)
-PyYAML>=6.0                      # config + device registry parsing
-paho-mqtt>=2.1.0                 # publishes device commands to mosquitto
+# Core runtime (kept in lock-step with requirements.txt)
+numpy==2.4.6
+onnxruntime==1.26.0
+tokenizers==0.23.1
+silero-vad==6.2.1
+sounddevice==0.5.5
+requests==2.34.2                 # HTTP to the local Ollama LLM
+useful-moonshine-onnx==20251121  # Moonshine STT (local, hash-verified models)
+PyYAML==6.0.3                    # config + device registry parsing
+paho-mqtt==2.1.0                 # publishes device commands to mosquitto
 openwakeword==0.4.0              # acoustic "hey clank" wake-word gate
 
-# Development and testing (optional)
-pytest>=7.0.0
-black>=23.0.0
-flake8>=6.0.0
+# Development and testing (optional; not imported at runtime)
+pytest==8.4.2
+black==25.9.0
+flake8==7.3.0
 
 # System dependencies (install via the system package manager):
 # - libsndfile + portaudio (for sounddevice)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,38 +1,48 @@
 # Clank Voice LED Control - Python Dependencies
+#
+# Versions are PINNED (==) to the exact releases audited and running on the
+# Clank box (Python 3.14.5, verified 2026-06-13 via `pip freeze`). Every direct
+# dependency below was confirmed to be the genuine, canonical project on PyPI
+# (publisher checked) before pinning — see docs/dependencies.md for the audit.
+# To move a pin: bump it here, re-test, then update docs/dependencies.md.
+
 # Speech processing and AI
-numpy>=1.21.0
-onnxruntime>=1.15.0
-tokenizers>=0.13.0
-silero-vad>=4.0.0
+numpy==2.4.6
+onnxruntime==1.26.0            # Microsoft; CPU ORT for Moonshine + wake word
+tokenizers==0.23.1            # Hugging Face; Moonshine tokenizer
+silero-vad==6.2.1            # snakers4 (MIT); voice-activity gate
 
-# Official Moonshine ONNX library (PyPI; used with local, hash-verified models)
-useful-moonshine-onnx>=20251121
+# Official Moonshine ONNX library (Useful Sensors; used with local,
+# hash-verified models fetched by scripts/fetch_moonshine.sh)
+useful-moonshine-onnx==20251121
 
-# Audio processing
-sounddevice>=0.4.6
+# Audio capture (spatialaudio/PortAudio bindings)
+sounddevice==0.5.5
 
-# HTTP requests and web communication
-requests>=2.28.0
+# HTTP to the local Ollama LLM (Python Software Foundation / requests team)
+requests==2.34.2
 
-# Acoustic wake-word engine (optional; used when audio.wake_engine: openwakeword).
-# Pinned to 0.4.0: it's the last release installable on Python 3.14 (newer
-# releases require tflite-runtime, which has no 3.14 wheel), it's onnx-only,
-# and ships its models bundled so it runs fully offline. The integration also
-# targets the 0.4.x API; its bundled models are SHA256-pinned in
-# voice_LED_control.py and integrity-checked at load.
+# Acoustic wake-word engine (used when audio.wake_engine: openwakeword).
+# David Scripka's openWakeWord. Pinned to 0.4.0: it's the last release
+# installable on Python 3.14 (newer releases require tflite-runtime, which has
+# no 3.14 wheel), it's onnx-only, and ships its models bundled so it runs fully
+# offline. The integration targets the 0.4.x API; its bundled models are
+# SHA256-pinned in voice_LED_control.py and integrity-checked at load.
 openwakeword==0.4.0
 
 # Configuration parsing — required by voicecommand.config (loaded at startup)
 # and the device registry (voicecommand.devices, config/devices.yaml).
-PyYAML>=6.0
+PyYAML==6.0.3
 
 # MQTT client — publishes device commands to the local mosquitto broker that
 # WLED and the OpenBeken plugs subscribe to (voicecommand MqttPublisher).
-paho-mqtt>=2.1.0
+# Eclipse Foundation (Eclipse Paho).
+paho-mqtt==2.1.0
 
 # System dependencies that may need to be installed via system package manager:
 # - libsndfile1 (for sounddevice)
 # - portaudio19-dev (for sounddevice)
-# 
+#
 # On Ubuntu/Debian: sudo apt-get install libsndfile1 portaudio19-dev
+# On Arch:          sudo pacman -S libsndfile portaudio
 # On macOS with Homebrew: brew install portaudio

--- a/scripts/train_wakeword/audit_onnx.py
+++ b/scripts/train_wakeword/audit_onnx.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Audit a (freshly trained) wake-word ONNX before trusting it, and print the
+SHA256 line to pin in Clank.
+
+ONNX is an executable graph format, so a model file is code. Before a new
+hey_clank.onnx is allowed anywhere near onnxruntime on the Clank box, it must
+pass the same bar as every other model we ship:
+
+  * opset domains are standard only ("" / ai.onnx / ai.onnx.ml) — no custom
+    operator domains (a custom domain can mean a custom .so is loaded);
+  * no external-data tensors (weights must be in-file, not a sidecar the loader
+    would fetch);
+  * no embedded URLs / absolute paths / metadata that points off-box;
+  * it loads under the stock onnxruntime CPU provider.
+
+On success it prints the exact line to paste into _KNOWN_OWW_SHA256 in
+src/voicecommand/voice_LED_control.py.
+
+Usage (in the training env, which has `onnx` installed):
+
+    python scripts/train_wakeword/audit_onnx.py models/wakeword/hey_clank.onnx
+
+Exit code is non-zero if any hard check fails.
+"""
+
+import argparse
+import hashlib
+import os
+import re
+import sys
+
+# Domains that ship with stock onnxruntime. Anything else means a custom op,
+# which can pull in native code — reject.
+_STD_DOMAINS = {"", "ai.onnx", "ai.onnx.ml"}
+
+# Look for anything that points off the box inside metadata / the raw bytes.
+_OFFBOX = re.compile(rb"https?://|file://|\\\\|/home/|/Users/|[A-Za-z]:\\")
+
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for block in iter(lambda: fh.read(65536), b""):
+            h.update(block)
+    return h.hexdigest()
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("model", help="Path to the .onnx file to audit.")
+    args = ap.parse_args()
+
+    if not os.path.exists(args.model):
+        sys.exit(f"No such file: {args.model}")
+
+    try:
+        import onnx
+    except ImportError:
+        sys.exit("This audit needs the `onnx` package: pip install onnx "
+                 "(install it in your training env, not the Clank runtime).")
+
+    digest = sha256_file(args.model)
+    size = os.path.getsize(args.model)
+    print(f"file   : {args.model}")
+    print(f"size   : {size:,} bytes")
+    print(f"sha256 : {digest}\n")
+
+    model = onnx.load(args.model)
+    problems = []
+    notes = []
+
+    # 1) Structural validity.
+    try:
+        onnx.checker.check_model(model)
+        print("[ok] onnx.checker passed")
+    except Exception as e:
+        problems.append(f"onnx.checker failed: {e}")
+
+    # 2) Opset / operator domains.
+    opset_domains = {op.domain for op in model.opset_import}
+    bad_opset = opset_domains - _STD_DOMAINS
+    versions = ", ".join(f"{op.domain or 'ai.onnx'}={op.version}"
+                         for op in model.opset_import)
+    print(f"[..] opset: {versions}")
+    if bad_opset:
+        problems.append(f"non-standard opset domain(s): {sorted(bad_opset)}")
+
+    op_types = {}
+    custom_nodes = []
+    for node in model.graph.node:
+        op_types[node.op_type] = op_types.get(node.op_type, 0) + 1
+        if node.domain not in _STD_DOMAINS:
+            custom_nodes.append(f"{node.op_type}@{node.domain}")
+    print(f"[..] op types ({len(op_types)}): "
+          + ", ".join(f"{k}×{v}" for k, v in sorted(op_types.items())))
+    if custom_nodes:
+        problems.append(f"custom-domain operators: {sorted(set(custom_nodes))}")
+    else:
+        print("[ok] all operators are in standard domains")
+
+    # 3) External data — weights must be in-file.
+    ext = []
+    for init in model.graph.initializer:
+        if init.data_location == onnx.TensorProto.EXTERNAL or init.external_data:
+            ext.append(init.name)
+    if ext:
+        problems.append(f"tensors stored as EXTERNAL data: {ext[:5]}"
+                        + (" …" if len(ext) > 5 else ""))
+    else:
+        print("[ok] no external-data tensors (weights are in-file)")
+
+    # 4) Metadata props.
+    if model.metadata_props:
+        for p in model.metadata_props:
+            line = f"{p.key}={p.value}"
+            if _OFFBOX.search(line.encode("utf-8", "ignore")):
+                problems.append(f"metadata points off-box: {line}")
+            else:
+                notes.append(f"metadata: {line}")
+    else:
+        print("[ok] no metadata_props")
+
+    # 5) Raw byte scan for off-box references / absolute paths.
+    with open(args.model, "rb") as fh:
+        raw = fh.read()
+    hits = sorted({m.group(0).decode("latin-1") for m in _OFFBOX.finditer(raw)})
+    if hits:
+        problems.append(f"off-box references in bytes: {hits[:8]}")
+    else:
+        print("[ok] no URLs / absolute paths in raw bytes")
+
+    # 6) Actually load it under stock CPU onnxruntime.
+    try:
+        import onnxruntime as ort
+        ort.InferenceSession(args.model, providers=["CPUExecutionProvider"])
+        print("[ok] loads under onnxruntime CPUExecutionProvider")
+    except ImportError:
+        notes.append("onnxruntime not in this env — skipped the load test")
+    except Exception as e:
+        problems.append(f"onnxruntime failed to load it: {e}")
+
+    if notes:
+        print("\nnotes:")
+        for n in notes:
+            print(f"  - {n}")
+
+    print()
+    if problems:
+        print("AUDIT FAILED — do NOT pin or ship this model:")
+        for p in problems:
+            print(f"  ✗ {p}")
+        sys.exit(1)
+
+    name = os.path.basename(args.model)
+    print("AUDIT PASSED ✓")
+    print("\nPin it: add this line to _KNOWN_OWW_SHA256 in "
+          "src/voicecommand/voice_LED_control.py")
+    print(f'    "{name}": "{digest}",')
+    print("\nand re-run SHA256SUMS if this file is tracked:")
+    print(f"    sha256sum {args.model}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_wakeword/record_samples.py
+++ b/scripts/train_wakeword/record_samples.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+"""Record wake-word training clips from the Clank mic.
+
+The single biggest lever on "hey clank" recall is training on audio from the
+*same microphone and room* Clank actually listens through. The openWakeWord
+pipeline trains mostly on synthetic (TTS) speech; folding in a few dozen real
+recordings from this mic closes the gap that shows up as "it scores 0.8 on a
+headset but 0.1 on the built-in mic".
+
+Records fixed-length 16 kHz mono WAV clips — the format the trainer expects.
+
+Examples (run from the repo root, in the Clank venv):
+
+    # 50 positive "hey clank" clips
+    .venv/bin/python scripts/train_wakeword/record_samples.py \
+        --label positive --count 50
+
+    # 30 "hard negative" clips: talk, but never say the wake word. These teach
+    # the model what NOT to fire on (TV, conversation, similar-sounding words).
+    .venv/bin/python scripts/train_wakeword/record_samples.py \
+        --label negative --count 30 --seconds 3
+
+Clips land in   data/wakeword/<label>/<label>_NNN.wav   by default.
+Press ENTER to record each clip; after each you can (k)eep, (r)edo, or (q)uit.
+"""
+
+import argparse
+import os
+import sys
+import time
+
+SAMPLE_RATE = 16000  # openWakeWord operates at 16 kHz mono.
+
+
+def _check_deps():
+    try:
+        import sounddevice  # noqa: F401
+        import soundfile  # noqa: F401
+    except ImportError as e:
+        sys.exit(
+            f"Missing audio dependency ({e.name}). These ship with Clank's "
+            "runtime venv — run this with .venv/bin/python from the repo root."
+        )
+
+
+def _countdown(prompt):
+    print(f"\n{prompt}")
+    for n in ("3", "2", "1", "GO"):
+        print(f"  {n}", end="\r" if n != "GO" else "\n", flush=True)
+        time.sleep(0.5)
+
+
+def record_one(seconds):
+    import sounddevice as sd
+
+    frames = int(seconds * SAMPLE_RATE)
+    audio = sd.rec(frames, samplerate=SAMPLE_RATE, channels=1, dtype="float32")
+    sd.wait()
+    return audio.reshape(-1)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--label", default="positive",
+                    help="Clip class / subfolder name (e.g. positive, negative).")
+    ap.add_argument("--count", type=int, default=50,
+                    help="How many clips to record this session.")
+    ap.add_argument("--seconds", type=float, default=2.0,
+                    help="Length of each clip in seconds (2.0 suits 'hey clank').")
+    ap.add_argument("--out", default="data/wakeword",
+                    help="Base output directory (subfolder per --label).")
+    ap.add_argument("--phrase", default="hey clank",
+                    help="What to say (shown as the prompt for positives).")
+    args = ap.parse_args()
+
+    _check_deps()
+    import sounddevice as sd
+    import soundfile as sf
+
+    out_dir = os.path.join(args.out, args.label)
+    os.makedirs(out_dir, exist_ok=True)
+
+    # Continue numbering after any existing clips so repeated sessions accrue.
+    existing = [f for f in os.listdir(out_dir)
+                if f.startswith(args.label + "_") and f.endswith(".wav")]
+    start_idx = len(existing)
+
+    try:
+        dev = sd.query_devices(kind="input")
+        print(f"Input device: {dev['name']}")
+    except Exception:
+        print("Input device: (default)")
+
+    say = (f"Say: \"{args.phrase}\"" if args.label == "positive"
+           else f"Make a NON-wake sound/speech for ~{args.seconds:.0f}s "
+                "(talk, TV, similar words — anything but the wake word)")
+    print(f"\nRecording {args.count} '{args.label}' clips of "
+          f"{args.seconds:.1f}s into {out_dir}/")
+    print("ENTER = record • after each: [k]eep / [r]edo / [q]uit\n")
+
+    saved = 0
+    idx = start_idx
+    while saved < args.count:
+        try:
+            input(f"[{saved + 1}/{args.count}] ENTER to record… ")
+        except (EOFError, KeyboardInterrupt):
+            print("\nStopping.")
+            break
+
+        while True:
+            _countdown(say)
+            audio = record_one(args.seconds)
+            peak = float(abs(audio).max()) if audio.size else 0.0
+            warn = "  ⚠ very quiet — move closer / raise mic gain" if peak < 0.02 else ""
+            warn = "  ⚠ clipping — lower mic gain" if peak > 0.99 else warn
+            print(f"  peak level: {peak:.3f}{warn}")
+            sd.play(audio, SAMPLE_RATE)
+            sd.wait()
+            choice = input("  [k]eep / [r]edo / [q]uit: ").strip().lower()
+            if choice == "r":
+                continue
+            if choice == "q":
+                print(f"\nDone. Saved {saved} clip(s) to {out_dir}/")
+                return
+            # default / 'k' -> keep
+            path = os.path.join(out_dir, f"{args.label}_{idx:03d}.wav")
+            sf.write(path, audio, SAMPLE_RATE, subtype="PCM_16")
+            print(f"  saved {path}")
+            saved += 1
+            idx += 1
+            break
+
+    print(f"\nDone. Saved {saved} clip(s) to {out_dir}/")
+    print("Next: feed these into the trainer — see docs/training-wakeword.md")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/train_wakeword/requirements-training.txt
+++ b/scripts/train_wakeword/requirements-training.txt
@@ -1,0 +1,53 @@
+# Wake-word TRAINING dependencies — a SEPARATE environment from Clank's runtime.
+#
+# ⚠ Do NOT install these into Clank's runtime venv. Training needs a heavy,
+#   older stack (torch, TF for tflite export, the openWakeWord training extras)
+#   that conflicts with the lean Python 3.14 runtime. Use a dedicated venv:
+#
+#       python3.11 -m venv ~/oww-training/.venv
+#       source ~/oww-training/.venv/bin/activate.fish
+#       pip install -r scripts/train_wakeword/requirements-training.txt
+#
+# Python 3.11 is the sweet spot: the openWakeWord training pipeline and its
+# dependencies (speechbrain, torch-audiomentations, piper-phonemize) have wheels
+# there; 3.12+ is hit-or-miss and 3.14 won't work.
+#
+# HONESTY NOTE: the Clank runtime pins (requirements*.txt) were verified on this
+# box. This training env could NOT be test-installed here, so treat the versions
+# below as a known-good starting point sourced from the openWakeWord training
+# notebook — if a resolve fails, the upstream notebook is the source of truth:
+#   https://github.com/dscripka/openWakeWord/blob/main/notebooks/automatic_model_training.ipynb
+# Every package below was checked to be the genuine, canonical project on PyPI.
+
+# --- Core: the trainer itself + ONNX tooling -------------------------------
+openwakeword==0.4.0           # David Scripka — same pin as the runtime
+onnx==1.21.0                  # ONNX team — needed by audit_onnx.py + export
+onnxruntime==1.26.0           # Microsoft — load test during audit
+
+# --- Recording / audio I/O for prepping clips ------------------------------
+sounddevice==0.5.5            # used by record_samples.py
+soundfile==0.14.0             # WAV read/write
+librosa==0.11.0               # feature extraction / resampling
+numpy==2.4.6
+scipy==1.17.1
+
+# --- openWakeWord training pipeline (from the upstream notebook) -----------
+# These produce the synthetic speech + augmentation the trainer expects.
+torch==2.2.2                  # PyTorch — training backend (CUDA build optional)
+torchaudio==2.2.2             # PyTorch — audio transforms
+torchinfo==1.8.0              # TylerYep — model summaries
+torchmetrics==1.3.2           # Lightning AI — training metrics
+speechbrain==0.5.16           # SpeechBrain team — embeddings/augmentation
+audiomentations==0.34.1       # iver56 — audio augmentation
+torch-audiomentations==0.11.1 # asteroid/iver56 — GPU audio augmentation
+acoustics==0.2.6              # python-acoustics — RIR / room simulation
+mutagen==1.47.0               # quodlibet — audio metadata
+pronouncing==0.2.0            # aparrish — CMU pronunciations (phrase variants)
+datasets==2.19.1              # Hugging Face — pulls precomputed negative features
+tqdm==4.68.1
+
+# --- Synthetic speech (Piper) ----------------------------------------------
+# piper-sample-generator (rhasspy) is a GIT clone, NOT a pip package — it
+# provides the TTS that creates the bulk of the positive "hey clank" samples:
+#   git clone https://github.com/rhasspy/piper-sample-generator
+# It pulls piper-phonemize / piper-tts as its own deps. See the training doc.


### PR DESCRIPTION
## What

Two things: a complete **"hey clank" retraining path** (the durable fix for wake-word recall on the laptop's built-in mic), and **exact, legitimacy-checked pins** for every dependency.

## Wake-word training

- **`docs/training-wakeword.md`** — full walkthrough: record clips → trainer → **mandatory ONNX audit + SHA256 re-pin**. Confirms training on the laptop is fine (disk + CPU time are the cost, not VRAM), and notes the verifier path doesn't drop into Clank's loader as-is.
- **`scripts/train_wakeword/record_samples.py`** — captures 16 kHz mono clips (positives + hard negatives) from the Clank mic, with level warnings for the gain sweet spot. Runs in the existing runtime venv.
- **`scripts/train_wakeword/audit_onnx.py`** — vets a freshly-trained `.onnx` the project's way (rejects custom op domains / external-data tensors / embedded URLs, confirms stock-CPU load) and prints the line to paste into `_KNOWN_OWW_SHA256`. Verified its hashing matches the shipped `hey_clank.onnx`.
- **`scripts/train_wakeword/requirements-training.txt`** — separate Python 3.11 env (flagged as not test-installed on the box; sourced from the upstream notebook).
- `data/` gitignored (recordings stay local); README points to the guide.

## Dependency pinning

- `requirements.txt` / `requirements-secure.txt`: `>=` → `==`, matching the exact versions running on the box (Python 3.14.5), each confirmed as the genuine canonical project on PyPI.
- **`docs/dependencies.md`** records the audit table and the model-integrity story (pinning wheels ≠ vetting model weights — that's what the ONNX hash-pins do).

## Testing

- `py_compile` + `--help` clean on both scripts.
- `audit_onnx.py` hashing verified against the pinned `hey_clank.onnx` (`1d0dfa7…` matches).
- requirements pins taken directly from `pip freeze` of the working venv.

🤖 Generated with [Claude Code](https://claude.com/claude-code)