### PR TITLE
fix(mqtt): publish device commands at QoS 1

### DIFF
--- a/src/voicecommand/voice_LED_control.py
+++ b/src/voicecommand/voice_LED_control.py
@@ -177,12 +177,14 @@ class MqttPublisher:
         )
 
     def publish(self, topic: str, payload):
-        """Publish one command to a device's topic (qos 0, not retained —
-        commands are momentary). Dicts/lists are JSON-encoded (WLED state
-        objects); strings are sent verbatim (plug ON/OFF payloads)."""
+        """Publish one command to a device's topic (qos 1, not retained —
+        commands are momentary, but qos 1 gets a broker-level delivery ack so a
+        single dropped packet doesn't silently lose the command). Dicts/lists
+        are JSON-encoded (WLED state objects); strings are sent verbatim (plug
+        ON/OFF payloads)."""
         if isinstance(payload, (dict, list)):
             payload = json.dumps(payload)
-        self.client.publish(topic, payload, qos=0, retain=False)
+        self.client.publish(topic, payload, qos=1, retain=False)
 
 
 class VoiceProcessor:


### PR DESCRIPTION
## Summary
Device commands were published at **QoS 0** (fire-and-forget, no delivery confirmation), so a single dropped packet while the subscriber was connected would silently lose the command — the intermittent "WLED didn't react" symptom.

Switches to **QoS 1**, which gets a broker-level delivery ack and retries. Confirmed working in live testing.

Note: QoS 1 covers dropped packets while the subscriber is *connected*; a command sent during a WLED reconnect window (non-retained, no persistent session) is still not delivered. If misses recur, the next levers are a persistent session / retained command topic, or thinning the per-command `psave` flash write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)