### PR TITLE
feat(audio): selectable input device + multi-mic guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,6 +397,7 @@ audio:
   vad_threshold: 0.5          # 0.0–1.0, raise to reduce false triggers
   min_silence_duration_ms: 300
   max_speech_seconds: 15
+  input_device: ""            # "" = OS default mic; or index / name / "pulse"
   wake_word: "clank"
   require_wake_word: true
   wake_engine: "text"         # "text" or "openwakeword"
@@ -418,6 +419,8 @@ security:
   log_transcripts: false      # keep raw speech ephemeral; true only for debugging
   enable_audit_logging: true
 ```
+
+> **Multiple mics / multi-room:** to have Clank listen to two microphones at once (e.g. one per floor) by mixing them into a single virtual source, see [docs/multi-mic.md](docs/multi-mic.md). It's a PipeWire-specific (Arch/Linux) setup that uses `audio.input_device: "pulse"`.
 
 ---
 

--- a/config/default.yaml
+++ b/config/default.yaml
@@ -9,6 +9,11 @@ audio:
   min_refresh_seconds: 0.2
   vad_threshold: 0.5
   min_silence_duration_ms: 300
+  # Capture device (PortAudio). Empty = OS default mic. Set to a device index,
+  # a name substring ("USB"), or a host-API name ("pulse") to pick a specific
+  # mic; `python -m sounddevice` lists them. For combining two mics into one
+  # source, see docs/multi-mic.md.
+  input_device: ""
   # Wake word: utterances not addressed to this word are discarded without
   # being sent to the LLM, logged, or retained. Fuzzy-matched so STT
   # mishearings (clink/crank/blank...) still trigger.

--- a/docs/multi-mic.md
+++ b/docs/multi-mic.md
@@ -1,0 +1,113 @@
+# Listening to two microphones at once (multi-room)
+
+This is a **niche, Linux/PipeWire-specific** setup. The default Clank install
+listens to a single microphone (your OS default input) and needs none of this.
+
+Use this if you want Clank to hear from **two mics simultaneously** — e.g. an
+internal mic downstairs and a USB mic upstairs — by mixing both into one virtual
+capture source. Whichever mic picks up "hey clank" triggers it.
+
+> Alternative: if your second mic is on a **different machine**, don't combine
+> audio — run a second Clank instance on that machine pointed at the same MQTT
+> broker. Each node handles its own room. This page is only for two mics on
+> **one** machine.
+
+## How it works
+
+PipeWire (via its PulseAudio compatibility layer) creates a **null sink** called
+`combined_mics`, loops both microphones into it, and exposes its monitor
+(`combined_mics.monitor`) as a source carrying both mics mixed together. Clank
+then captures from that monitor.
+
+Three pieces are needed:
+
+1. a PipeWire drop-in that builds the combined source on login;
+2. `audio.input_device: "pulse"` so Clank captures through PipeWire (not raw ALSA);
+3. `PULSE_SOURCE=combined_mics.monitor` so libpulse opens the combined source.
+
+## 1. Create the combined source
+
+Find your two microphones' source names:
+
+```fish
+pactl list sources short
+```
+
+Look for the `alsa_input.*` entries (ignore `*.monitor` — those are output
+monitors). Then create the drop-in file
+`~/.config/pipewire/pipewire-pulse.conf.d/combine-mics.conf` with **your** two
+source names substituted:
+
+```
+# Combines two mics into one virtual source (combined_mics.monitor)
+# so Clank can hear from both at once.
+pulse.cmd = [
+    { cmd = "load-module" args = "module-null-sink sink_name=combined_mics sink_properties='node.description=Combined Microphones'" }
+    { cmd = "load-module" args = "module-loopback source=alsa_input.pci-0000_00_1f.3.analog-stereo sink=combined_mics latency_msec=1" }
+    { cmd = "load-module" args = "module-loopback source=alsa_input.usb-Generic_USB_AUDIO_20230714100308-00.analog-stereo sink=combined_mics latency_msec=1" }
+]
+```
+
+Replace the two `source=alsa_input....` names with yours. Restart PipeWire's
+pulse layer to load it (or just log out and back in):
+
+```fish
+systemctl --user restart pipewire-pulse
+```
+
+Verify the combined source now exists:
+
+```fish
+pactl list sources short | grep combined_mics
+```
+
+This auto-loads on every login — no service or cron job needed. If a mic isn't
+plugged in when PipeWire starts, that one loopback fails silently and Clank
+still hears the other mic.
+
+## 2. Point Clank at PipeWire
+
+In `config/default.yaml`:
+
+```yaml
+audio:
+  input_device: "pulse"
+```
+
+`"pulse"` is required here: the raw ALSA `"default"` device ignores
+`PULSE_SOURCE`, so the combined virtual source would never be selected.
+
+## 3. Select the combined source at launch
+
+`start_clank.sh` (or however you launch Clank) must export `PULSE_SOURCE`
+**before** the Python process starts:
+
+```sh
+export PULSE_SOURCE=combined_mics.monitor
+```
+
+(This is intentionally **not** committed in `start_clank.sh` — the source name
+only exists on a machine that has set up the drop-in above.)
+
+Restart Clank. Use `--oww-debug` (or watch the logs) to confirm the wake score
+spikes when you speak into *either* mic.
+
+## Why `combined_mics` shows up as an *output* device
+
+Expected. A null sink is technically an output — both mics "play into" it. Clank
+reads from its **monitor**, which is the passthrough of everything routed in.
+The sink itself is just internal plumbing; nothing actually plays through it.
+
+## Tuning the noise floor
+
+Mixing two mics at 100% each **sums both rooms' background noise** continuously,
+which can hurt wake-word recall. Balance the levels — turn the noisier room's mic
+down so its ambient noise doesn't drown the wake word:
+
+```fish
+pactl list sink-inputs short                 # find each loopback's index
+pactl set-sink-input-volume <index> 50%      # e.g. quiet the AC-noisy room
+```
+
+You may also need a slightly lower `audio.oww_threshold` to catch borderline
+hits on the mixed signal (the bundled config already runs sensitive).

--- a/src/voicecommand/config.py
+++ b/src/voicecommand/config.py
@@ -15,6 +15,12 @@ class AudioConfig:
     min_refresh_seconds: float = 0.2
     vad_threshold: float = 0.5
     min_silence_duration_ms: int = 300
+    # Capture device passed to PortAudio (sounddevice). Empty = the OS default
+    # input (current behaviour). Set to a device index, a name substring (e.g.
+    # "USB"), or a host-API name ("pulse") to pin Clank to a specific mic —
+    # `python -m sounddevice` lists the options. See docs/multi-mic.md for the
+    # PipeWire two-mic combine setup that uses input_device: "pulse".
+    input_device: str = ""
     # Wake word: utterances that don't begin with (a near-match of) this word
     # are discarded without being sent to the LLM, logged, or retained. Set
     # require_wake_word False to act on every utterance (less private).

--- a/src/voicecommand/voice_LED_control.py
+++ b/src/voicecommand/voice_LED_control.py
@@ -638,6 +638,8 @@ def main():
         channels=1,
         blocksize=CHUNK_SIZE,
         dtype=np.float32,
+        # Empty config -> None -> PortAudio's default input device.
+        device=config.audio.input_device or None,
         callback=create_input_callback(q),
     )
 


### PR DESCRIPTION
## Summary
Splits the laptop's two-mic work into the **general** part (merged as a feature) and the **niche** part (documented).

- **`audio.input_device`** — Clank always opened PortAudio's default input; this exposes the capture device as a config setting passed to `InputStream` (index / name substring / host-API name like `pulse`). Default `""` → `None` → OS default, so **existing setups are unchanged**.
- **`docs/multi-mic.md`** — the PipeWire null-sink + loopback recipe to combine two mics into one virtual source for a single Clank instance, using `input_device: "pulse"` + `PULSE_SOURCE`. Linked from the README config reference.

Kept as a doc, not a script: the right device names are per-machine and the core is a declarative PipeWire drop-in, not a command to run. `start_clank.sh` deliberately does **not** hardcode `PULSE_SOURCE` (that source only exists on a machine set up per the doc).

## Verification
`ClankConfig('config/default.yaml')` loads with `input_device == ""` → `None` (default-device behavior preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)